### PR TITLE
adjust color of links for this class combo

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -79,6 +79,14 @@ body {
     font-weight: 600;
 }
 
+.error-container .btn-danger {
+    color: white;
+}
+
+.error-container .btn-danger:hover {
+    color: white;
+}
+
 .error-container a:hover {
     text-decoration: none;
 }


### PR DESCRIPTION
Adds an override for the `.error-container .btn-danger` class combination and sets the color to white within it in the global.css.

<img width="659" height="321" alt="image" src="https://github.com/user-attachments/assets/2ef4b09a-46c0-4292-a68c-b9b22fea5957" />