### PR TITLE
Edit credits: add developer names, correct repo URL

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -88,6 +88,7 @@
 
     <div class="about-section">
         <h2>Source Code</h2>
+        <p>The source code for this project is published on GitHub. Please feel free to contribute or report issues.</p>
         <p>
             <a href="https://github.com/romangarms/OP1Z-Sample-Manager" target="_blank" rel="noopener noreferrer" class="github-button">
                 <i data-lucide="github"></i>


### PR DESCRIPTION
Credits should include dev names + personal sites, not just FFMPEG library. Additionally, link to the GitHub repo better

Closes #41 