### PR TITLE
Add description text to all pages

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -163,6 +163,14 @@ h1 {
     text-align: center;
 }
 
+.page-description {
+    text-align: center;
+    color: var(--text-secondary);
+    margin-top: -10px;
+    margin-bottom: 25px;
+    font-size: 0.95rem;
+}
+
 h3 {
     line-height: 1.5;
 }

--- a/templates/about.html
+++ b/templates/about.html
@@ -60,6 +60,7 @@
 
 {% block main %}
 <h1>About</h1>
+<p class="page-description">Information about this utility and how to get support.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -12,6 +12,7 @@
 {% block main %}
 
 <h1>Backup & Restore</h1>
+<p class="page-description">Create backups of your device's samples and projects, or restore from a previous backup.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}

--- a/templates/configeditor.html
+++ b/templates/configeditor.html
@@ -11,6 +11,7 @@
 
 {% block main %}
 <h1>OP-Z Config Editor</h1>
+<p class="page-description">Edit your OP-Z configuration files for custom MIDI assignments and settings.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}

--- a/templates/sampleconverter.html
+++ b/templates/sampleconverter.html
@@ -11,6 +11,7 @@
 
 {% block main %}
 <h1>OP-Z Sample Converter</h1>
+<p class="page-description">Convert audio files to the OP-1/OP-Z format for manual transfer to your device.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}

--- a/templates/samplemanager.html
+++ b/templates/samplemanager.html
@@ -11,6 +11,7 @@
 
 {% block main %}
 <h1>Sample Manager</h1>
+<p class="page-description">Drop any audio file into a slot for it to be automatically converted to the OP-1/OP-Z audio format and placed in the correct directory.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}

--- a/templates/tapeexport.html
+++ b/templates/tapeexport.html
@@ -12,6 +12,7 @@
 {% block main %}
 
 <h1>OP-1 Tape Export</h1>
+<p class="page-description">Export tape tracks from your OP-1 to your Downloads folder as audio files.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}

--- a/templates/utilitysettings.html
+++ b/templates/utilitysettings.html
@@ -11,6 +11,7 @@
 
 {% block main %}
 <h1>OP-Z Sample Manager and Converter Utility Settings</h1>
+<p class="page-description">Configure application settings and device paths.</p>
 
 <div class="header-row">
     {{ nav_button('/', 'Home', icon='home') }}


### PR DESCRIPTION
<img width="1392" height="832" alt="image" src="https://github.com/user-attachments/assets/b0a7d8e0-320f-445f-8387-1eeffddde5f5" />

Functionality of the sample manager page isn't the clearest, it may not be obvious that any audio file is supported, not just the OP-1 Aiff 16bit etc format

Closes #45 