### PR TITLE
fix default working dir path on windows

### DIFF
--- a/blueprints/config.py
+++ b/blueprints/config.py
@@ -36,7 +36,25 @@ app_config = {}
 
 def get_default_working_directory():
     """Return default working directory: ~/Documents/<PROJECT_NAME>/"""
-    documents = os.path.expanduser("~/Documents")
+    if sys.platform == 'win32':
+        # On Windows, use registry or USERPROFILE to find actual Documents folder
+        # This handles OneDrive redirection and custom locations
+        try:
+            import winreg
+            # Query Windows registry for the actual Documents folder location
+            key = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
+            )
+            documents = winreg.QueryValueEx(key, "Personal")[0]
+            winreg.CloseKey(key)
+        except Exception:
+            # Fallback to USERPROFILE if registry fails
+            documents = os.path.join(os.environ.get('USERPROFILE', os.path.expanduser('~')), 'Documents')
+    else:
+        # On macOS and Linux, ~/Documents works correctly
+        documents = os.path.expanduser("~/Documents")
+
     return os.path.join(documents, PROJECT_NAME)
 
 # Utility to read JSON from a file and return it as a Python object


### PR DESCRIPTION
Goes to onedrive documents if exists

Without this change, backups/audio files would get saved under a new Documents folder in your user folder, rather than locating your existing Documents folder.

This is because if you use OneDrive, your documents folder is actually located under `onedrive/documents` in your userfolder, not just `/documents`