### PR TITLE
fix: enable text selection in webview window

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
         width=1280,
         height=800,
         background_color="#1a1a1a",  # Matches loading screen - no white flash
+        text_select=True
     )
 
     # Wait for loading screen DOM to be ready, then start polling Flask


### PR DESCRIPTION
# PR Description
enable text selection in webview window

## Summary
<img width="1272" height="784" alt="Screenshot 2026-01-13 231249" src="https://github.com/user-attachments/assets/128e05f5-202a-439a-abcc-b4c210b534c8" />
## Motivation


## Issues
Resolves #76 


## How Has This Been Tested?

> Use the `build.py` script to perform the build.     --->done 

 - [done ] **Manual Step 1:** (eg. Open Utility Settings)
 - [done ] **Manual Step 2:** (eg. Toggle "Developer Mode")
 - [done ] **Expected Result:** (eg. Developer Mode settings are now visible)

### Environment

**List any relevant environment information**

 - OS -> Windows 11 
 - Python version -> python3.10.11


# Checklist:

 - [done ] I have performed a self-review of my own code 
 - [ done] I have verified the changes work as expected in a local environment