### PR TITLE
Remove stale config for devices not currently connected

### DIFF
--- a/blueprints/device_monitor.py
+++ b/blueprints/device_monitor.py
@@ -479,6 +479,14 @@ def scan_for_connected_devices():
     except Exception as e:
         print(f"Error scanning for USB devices: {e}")
 
+    # Clear stale config for devices that weren't found during scan
+    for device in ["opz", "op1"]:
+        with device_status_lock:
+            was_found = device_status[device]["connected"]
+        if not was_found:
+            # This will clear any stale config path via update_device_status logic
+            update_device_status(device, connected=False, path=None, usb_detected=False, mode=None)
+
 
 def start_usb_monitoring():
     """Start the USB monitoring thread."""


### PR DESCRIPTION
# PR Description
<!--
Please fill out this template to the best of your ability.

If it is not ready to be reviewed, please make this a "draft pull request", and change it to a pull request when ready.
-->

## Summary
Devices disconnecting wouldn't always remove their entry from the config file (what if they were removed when app wasn't running?)


## Motivation
Bad config entries like this would display the error "OP-Z mount path does not exist: F:" on the sample manager page, when it should instead show our "Please connect your OP-Z and try again. If it isn't being detected, go to Utility Settings, enable developer mode, and select the device path." message.

## Issues
Resolves #105 

Note any related issues (Delete if there are none)

## How Has This Been Tested?

> ⚠️ **PRs should not be considered tested unless the application has been successfully built.**  
> Use the `build.py` script to perform the build.

**Since we do not currently have automated tests, please describe the manual steps taken to verify these changes.**

 - [x] **Manual Step 1:** Connected device
 - [x] **Manual Step 2:** Disconnect device
 - [x] **Expected Result:**  Correct error message in sample manager

### Environment

**List any relevant environment information**

 - OS: Windows 11
 - Python version: 3.12
 - Any Device(s) this was tested with [OP-1, OP-Z]: OP-1 and OP-Z

# Checklist:

 - [x] I have performed a self-review of my own code
 - [x] I have verified the changes work as expected in a local environment
 - [x] I have commented my code, particularly in hard-to-understand areas