### PR TITLE
Add centralized device configuration using frozen dataclasses (fixes …

### DIFF
--- a/blueprints/device_monitor.py
+++ b/blueprints/device_monitor.py
@@ -95,8 +95,7 @@ def validate_device_folder_structure(device, mount_path):
         "5-bass", "6-lead", "7-arpeggio", "8-chord"
     ]
 
-    device_obj = get_device_by_id(device)
-    device_name = device_obj.name if device_obj else ("OP-1" if device == "op1" else "OP-Z")
+    device_name = get_device_by_id(device).name
 
     if not mount_path:
         return False, f"Please connect your {device_name} and try again. If it isn't being detected, go to Utility Settings, enable developer mode, and select the device path."
@@ -253,8 +252,7 @@ def update_device_status(device, connected, path=None, usb_detected=False, mode=
 
     # Only broadcast if status changed
     if old_status != new_status:
-        device_obj = get_device_by_id(device)
-        device_name = device_obj.name if device_obj else ("OP-1" if device == "op1" else "OP-Z")
+        device_name = get_device_by_id(device).name
         print(f"Broadcasting SSE: {device_name} connected={connected}, path={path}, mode={mode}")
         broadcast_sse_event("device_status", {
             "device": device,
@@ -582,8 +580,7 @@ def device_events():
                 import json
                 for device in ["opz", "op1"]:
                     status = device_status[device].copy()
-                    device_obj = get_device_by_id(device)
-                    device_name = device_obj.name if device_obj else device.upper()
+                    device_name = get_device_by_id(device).name
                     event_data = json.dumps({
                         "type": "device_status",
                         "device": device,

--- a/blueprints/devices.py
+++ b/blueprints/devices.py
@@ -5,7 +5,13 @@ Centralized device configuration for OP-Z and OP-1 devices.
 Provides a single source of truth for device names, constants, and capabilities.
 """
 from dataclasses import dataclass
-from typing import Optional
+
+
+class DeviceNotFoundError(Exception):
+    """Raised when a device ID is not recognized in the configuration."""
+    def __init__(self, device_id: str):
+        self.device_id = device_id
+        super().__init__(f"Unknown device identifier: '{device_id}'")
 
 
 @dataclass(frozen=True)
@@ -77,20 +83,23 @@ OP_1 = Device(
 )
 
 
-def get_device_by_id(device_id: str) -> Optional[Device]:
+def get_device_by_id(device_id: str) -> Device:
     """Get device configuration by ID.
     
     Args:
         device_id: Device identifier ("opz" or "op1")
         
     Returns:
-        Device object if found, None otherwise
+        Device object for the given ID
+        
+    Raises:
+        DeviceNotFoundError: If device_id is not recognized
     """
     if device_id == "opz":
         return OP_Z
     elif device_id == "op1":
         return OP_1
-    return None
+    raise DeviceNotFoundError(device_id)
 
 
 def get_all_devices() -> tuple[Device, Device]:

--- a/blueprints/sample_manager.py
+++ b/blueprints/sample_manager.py
@@ -66,12 +66,8 @@ def get_device_config(device=None):
         tuple: (mount_path, device_name)
     """
     if device is None:
-        device = get_config_setting("SELECTED_DEVICE")
-    device_obj = get_device_by_id(device)
-    if device_obj:
-        return get_device_mount_path(device), device_obj.name
-    # Fallback for unknown devices
-    return get_device_mount_path(device), device.upper()
+        device = get_config_setting(CONFIG_SELECTED_DEVICE)
+    return get_device_mount_path(device), get_device_by_id(device).name
 
 
 def sanitize_and_validate_path(allowed_base, *path_components):


### PR DESCRIPTION
## Summary

Added a centralized device configuration module (`blueprints/devices.py`) using **frozen dataclasses** to manage device names, constants, and capabilities for **OP-1** and **OP-Z** devices.

Replaced hardcoded strings and magic numbers across the codebase with references to this single source of truth.

---

## Motivation

Previously, device names (`"OP-1"`, `"OP-Z"`), USB IDs, storage limits, and sample limits were hardcoded in multiple files. This made the codebase:

- Harder to maintain
- Error-prone when adding or updating devices
- Difficult to extend in a consistent way

This change introduces a **centralized, type-safe configuration system** that is easier to maintain, reason about, and extend.

---

## Issues

Resolves #87 
