### PR TITLE
fix: Change FFMPEG binary download

### DIFF
--- a/build.py
+++ b/build.py
@@ -97,7 +97,7 @@ def download_ffmpeg_macos():
         # Extract ffmpeg from gzipped binary.
         print("Extracting FFMPEG...")
         with gzip.open(tmp_path, 'rb') as src, open(ffmpeg_path, 'wb') as dst:
-            dst.write(src.read())
+            shutil.copyfileobj(src, dst)
         os.chmod(ffmpeg_path, 0o755)
         print(f"FFMPEG installed to: {ffmpeg_path}")
         return True
@@ -125,7 +125,7 @@ def download_ffmpeg_windows():
         # Extract ffmpeg.exe from gzipped binary.
         print("Extracting FFMPEG...")
         with gzip.open(tmp_path, 'rb') as src, open(ffmpeg_path, 'wb') as dst:
-            dst.write(src.read())
+            shutil.copyfileobj(src, dst)
         print(f"FFMPEG installed to: {ffmpeg_path}")
         return True
     finally:


### PR DESCRIPTION
# PR Description
<!--
Please fill out this template to the best of your ability.

If it is not ready to be reviewed, please make this a "draft pull request", and change it to a pull request when ready.
-->

## Summary
Briefly describe what this PR changes. Attach a screenshot if the PR contains a GUI change.
Changes the download source of FFMPEG to https://github.com/eugeneware/ffmpeg-static/releases

## Motivation
Why is this change needed? What problem does it solve?
Our builds were failing

## Issues
Resolves #120 

## How Has This Been Tested?

Triggered a release on main of my branch
https://github.com/alterednode/OP1Z-Sample-Manager/releases/tag/v2.1.0

I have not tested it myself but the builds did not fail so it should be fine?
It might be smart to add a small check thing that tests if the FFMPEG binary that we download does work before continuing with the build.

# Checklist:

 - [x] I have performed a self-review of my own code
 - [x] I have verified the changes work as expected in a local environment
 - [x] I have commented my code, particularly in hard-to-understand areas