### PR TITLE
Add backend for login / logout of op1.fun

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from blueprints.dialogs import dialog_bp
 from blueprints.backup import backup_bp
 from blueprints.device_monitor import device_monitor_bp, initialize_device_monitor
 from blueprints.update_checker import update_checker_bp
+from blueprints.integrations import integrations_bp
 
 
 # Get base path for PyInstaller or normal execution
@@ -35,6 +36,7 @@ app.register_blueprint(dialog_bp)
 app.register_blueprint(backup_bp)
 app.register_blueprint(device_monitor_bp)
 app.register_blueprint(update_checker_bp)
+app.register_blueprint(integrations_bp)
 
 # run before server startup at the end of this file
 def app_startup_tasks():

--- a/blueprints/constants.py
+++ b/blueprints/constants.py
@@ -27,6 +27,12 @@ class Config:
         OPZ_DETECTED = "OPZ_DETECTED_PATH"
         OP1_DETECTED = "OP1_DETECTED_PATH"
 
+    # Third-party integrations
+    class Integrations:
+        """Configuration keys for external service integrations."""
+        OP1FUN_USER_EMAIL = "OP1FUN_USER_EMAIL"
+        OP1FUN_USER_TOKEN = "OP1FUN_USER_TOKEN"
+        OP1FUN_TOKEN_OBTAINED_AT = "OP1FUN_TOKEN_OBTAINED_AT"
 
 # ===================================================================
 # Directory Names
@@ -99,3 +105,13 @@ class TapeAlbum:
     """OP-1 tape and album track/side identifiers."""
     TRACK_IDS = [1, 2, 3, 4]
     SIDE_IDS = ["a", "b"]
+
+# ===================================================================
+# op1.fun Integration Constants
+# ===================================================================
+
+class OP1FUN:
+    """Constants related to the op-1.fun integration."""
+
+    OP1FUN_API_BASE_URL = "https://api.op1.fun/v1"
+    OP1FUN_API_TOKEN_URL = f"{OP1FUN_API_BASE_URL}/api_token"

--- a/blueprints/integrations/__init__.py
+++ b/blueprints/integrations/__init__.py
@@ -1,0 +1,12 @@
+"""Integrations blueprint package.
+
+Keep this module lightweight: define the blueprint and import route modules
+so their decorators register endpoints.
+"""
+
+from flask import Blueprint
+
+integrations_bp = Blueprint("integrations", __name__)
+
+# Import route modules so their decorators register endpoints
+from . import op1fun  # noqa: F401,E402

--- a/blueprints/integrations/op1fun.py
+++ b/blueprints/integrations/op1fun.py
@@ -1,0 +1,151 @@
+"""
+At the moment, this contains all the op-1.fun integration code.
+We may convert this to a package if we add more integrations later, or the code grows too large.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from flask import jsonify, request, current_app
+
+from ..config import delete_config_setting, get_config_setting, set_config_setting
+from ..constants import Config, OP1FUN
+from . import integrations_bp
+
+
+class Op1FunTokenError(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def _json_or_none(response: requests.Response) -> dict[str, Any] | None:
+    try:
+        data = response.json()
+        if isinstance(data, dict):
+            return data
+    except ValueError:
+        return None
+    return None
+
+
+def build_op1fun_auth_header() -> dict[str, str] | None:
+    """Build auth headers for op-1.fun authenticated requests.
+
+    Per op-1.fun docs, all requests except API token lookup must include:
+    - X-User-Token
+    - X-User-Email
+
+    Returns None if token/email are not configured.
+    """
+    token = get_config_setting(Config.Integrations.OP1FUN_USER_TOKEN, "")
+    email = get_config_setting(Config.Integrations.OP1FUN_USER_EMAIL, "")
+    if not token or not email:
+        return None
+
+    return {
+        "accept": "application/json",
+        "X-User-Token": token,
+        "X-User-Email": email,
+    }
+
+
+@integrations_bp.route("/integrations/op1fun/api_token", methods=["POST"])
+def op1fun_api_token_lookup():
+    """Exchange email/password for an op-1.fun API token and store it.
+
+    Request JSON:
+      {"email": "user@example.com", "password": "..."}
+
+    Response JSON:
+      {"success": true, "api_token": "..."}
+
+    Notes:
+    - This endpoint does not persist the password.
+    - The token + email are stored in app config for future op-1.fun requests.
+    """
+
+    data = request.get_json(silent=True) or {}
+    email = (data.get("email") or "").strip()
+    password = data.get("password") or ""
+
+    if not email or not password:
+        return jsonify({"success": False, "error": "Missing 'email' or 'password'"}), 400
+
+    try:
+        api_token = _attempt_op1fun_token_lookup_and_save(email, password)
+    except Op1FunTokenError as exc:
+        return jsonify({"success": False, "error": exc.message}), exc.status_code
+
+    return jsonify({"success": True, "api_token": api_token})
+
+
+def _attempt_op1fun_token_lookup_and_save(email: str, password: str) -> str:
+    try:
+        resp = requests.post(
+            OP1FUN.OP1FUN_API_TOKEN_URL,
+            headers={
+                "accept": "application/json",
+                "content-type": "application/json",
+            },
+            json={
+                "email": email,
+                "password": password,
+            },
+            timeout=15,
+        )
+    except requests.exceptions.Timeout:
+        current_app.logger.error("op-1.fun token lookup timed out")
+        raise Op1FunTokenError("op-1.fun token lookup timed out", 504)
+    except requests.exceptions.RequestException as e:
+        current_app.logger.error("op-1.fun token lookup request failed: %s", e)
+        raise Op1FunTokenError("op-1.fun token lookup request failed", 502)
+
+    payload = _json_or_none(resp)
+
+    if resp.status_code != 200:
+        message = None
+        if payload:
+            message = payload.get("error") or payload.get("message")
+        if not message:
+            message = "Authentication failed"
+        raise Op1FunTokenError(message, resp.status_code)
+
+    if not payload or not payload.get("api_token"):
+        current_app.logger.error(
+            "op-1.fun token lookup succeeded but response JSON was unexpected (status=%s)",
+            resp.status_code,
+        )
+        raise Op1FunTokenError("Unexpected response from op-1.fun", 502)
+
+    api_token = payload["api_token"]
+
+    # Store for future authenticated API requests
+    set_config_setting(Config.Integrations.OP1FUN_USER_EMAIL, email)
+    set_config_setting(Config.Integrations.OP1FUN_USER_TOKEN, api_token)
+    set_config_setting(
+        Config.Integrations.OP1FUN_TOKEN_OBTAINED_AT,
+        datetime.now(timezone.utc).isoformat()
+    )
+    return api_token
+
+
+def _clear_op1fun_auth():
+    """Clear stored op-1.fun authentication token and email."""
+    delete_config_setting(Config.Integrations.OP1FUN_USER_EMAIL)
+    delete_config_setting(Config.Integrations.OP1FUN_USER_TOKEN)
+    delete_config_setting(Config.Integrations.OP1FUN_TOKEN_OBTAINED_AT)
+
+
+@integrations_bp.route("/integrations/op1fun/clear_auth", methods=["POST"])
+def op1fun_clear_auth():
+    """Clear stored op-1.fun authentication token and email.
+    Response JSON:
+      {"success": true}
+    """
+    _clear_op1fun_auth()
+    return jsonify({"success": True})


### PR DESCRIPTION
# PR Description
<!--
Please fill out this template to the best of your ability.

If it is not ready to be reviewed, please make this a "draft pull request", and change it to a pull request when ready.
-->

## Summary
This adds a backend to login to the op1.fun api, then store the email and token.

It also adds a logout / clear_auth endpoint.

## Motivation
Why is this change needed? What problem does it solve?

this is needed in order to complete #116 

## How Has This Been Tested?

I used
```
$body = @{
  email    = "user@example.com"
  password = "LongSecurePassword81734"
} | ConvertTo-Json

Invoke-RestMethod -Method Post `
  -Uri "http://127.0.0.1:5000/integrations/op1fun/api_token" `
  -ContentType "application/json" `
  -Body $body
  ```
  and 
  ```
  Invoke-RestMethod -Method Post `
  -Uri "http://127.0.0.1:5000/integrations/op1fun/clear_auth"
  ```
  to test our api, I both got the token and successfully cleared it (checked by monitoring the config file)
  
equivalent curl:
```
curl -i -X POST "http://127.0.0.1:5000/integrations/op1fun/api_token" `
  -H "accept: application/json" `
  -H "content-type: application/json" `
  --data "{\"email\":\"user@example.com\",\"password\":\"LongSecurePassword81734\"}"

and

curl -i -X POST "http://127.0.0.1:5000/integrations/op1fun/clear_auth"
```

### Environment

Windows11, 3.13.7

# Checklist:

 - [x] I have performed a self-review of my own code
 - [x] I have verified the changes work as expected in a local environment
 - [x] I have commented my code, particularly in hard-to-understand areas